### PR TITLE
handle empty action name

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -34,9 +34,10 @@ class Module implements
 		$oRouter = $oEvent->getRouteMatch();
 		if($oRouter instanceof \Zend\Mvc\Router\RouteMatch){
 			if($sControllerName = $oRouter->getParam('controller'))$sModuleName = current(explode('\\',ltrim($sControllerName,'\\')));
+			$sActionName = $oRouter->getParam('action');
 			$oOptions = $oAssetsBundleService->getOptions()
-				->setControllerName($sControllerName)
-				->setActionName($oRouter->getParam('action'));
+				->setControllerName($sControllerName);
+			if(!empty($sActionName))$oOptions->setActionName($sActionName);
 			if(!empty($sModuleName))$oOptions->setModuleName($sModuleName);
 		}
 		$oAssetsBundleService->renderAssets();


### PR DESCRIPTION
In my setup i have a mix of normal controllers for serving views and a rest api for data transaction.

Unfortunately AssetsBundle triggers always and awaits an Action Name. 

Controller of Type \Zend\Mvc\Controller\AbstractRestfulController don't have an action name.

Therefore it now checks first if there is an Action name (like the Module name check) and sets it afterwards.

This is just to fix the InvalidArgumentException, it would be still nice to have some way of disabling the AssetsBundle on certain calls.
