### PR TITLE
detect module if the controller is defined with alias

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -33,7 +33,24 @@ class Module implements
 		/* @var $oRouter \Zend\Mvc\Router\RouteMatch */
 		$oRouter = $oEvent->getRouteMatch();
 		if($oRouter instanceof \Zend\Mvc\Router\RouteMatch){
-			if($sControllerName = $oRouter->getParam('controller'))$sModuleName = current(explode('\\',ltrim($sControllerName,'\\')));
+			if($sControllerName = $oRouter->getParam('controller'))
+			{
+				if(strpos($sControllerName, '\\'))
+				{
+					$sModuleName = current(explode('\\', ltrim($sControllerName, '\\')));
+				}
+				if(!isset($sModuleName) || empty($sModuleName))
+				{
+					$config = $oEvent->getApplication()->getServiceManager()->get('Config');
+					if(isset($config['controllers']['invokables']) && is_array($config['controllers']['invokables']))
+					{
+						if(array_key_exists($sControllerName, $config['controllers']['invokables']))
+						{
+						    $sModuleName = current(explode('\\', ltrim($config['controllers']['invokables'][$sControllerName], '\\')));
+						}
+					}
+				}
+			}
 			$sActionName = $oRouter->getParam('action');
 			$oOptions = $oAssetsBundleService->getOptions()
 				->setControllerName($sControllerName);


### PR DESCRIPTION
If the controller is defined in this way:
controllers' => array (
    'invokables' => array (
      'test' => 'Test\Controller\TestController',
));
then $MvcEvent->getRouteMatch()->getParam('controller') will return 'test' instead of 'Test\Controller\TestController'.

In this case module name can't be detected using explode by '\' cause will end in an error moduleName = controllerName (cause controller does not contain any '\')

NB: maybe is not the cleaner solution but can be a start point and it works :)
