### PR TITLE
Fix path in resources with absolute path

### DIFF
--- a/src/AssetsBundle/View/Strategy/ViewHelperStrategy.php
+++ b/src/AssetsBundle/View/Strategy/ViewHelperStrategy.php
@@ -8,7 +8,10 @@ class ViewHelperStrategy extends \AssetsBundle\View\Strategy\AbstractStrategy{
 	public function renderAsset($sPath,$iLastModified){
     	$sExtension = strtolower(pathinfo($sPath, PATHINFO_EXTENSION));
 
-    	$sPath = $this->getBaseUrl().$sPath.(strpos($sPath, '?')?'&':'?').($iLastModified?:time());
+        // Is an absolute path?
+        if(!preg_match('/^https?:\/\//', $sPath))
+            $sPath = $this->getBaseUrl().$sPath.(strpos($sPath, '?')?'&':'?').($iLastModified?:time());
+
         switch($sExtension){
             case 'js':
             	$this->getRenderer()->plugin('InlineScript')->appendFile($sPath);


### PR DESCRIPTION
Example:

Add this file: http://ajax.googleapis.com/ajax/libs/mootools/1.4.5/mootools.js
Return: /cache/http://ajax.googleapis.com/ajax/libs/mootools/1.4.5/mootools.js

In developement environment.
