### PR TITLE
#34 Updated README.md to improve clarity around defining the module in a...

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ Installation
         'modules' => array(
             // ...
             'AssetsBundle',
+            // ...
         ),
         // ...
     );
     ```
+You should note that as the ordering of modules matters, you should declare the 'AssetsBundle' module before your application modules to ensure the default settings don't take priority.
 
 2. Insert css & js files into your layout page
 


### PR DESCRIPTION
A small change to add some additional clarity around defining the module in the application.config.php. If the AssetsBundle module is defined after the application modules, the asset_bundle's default config settings may take precedence. This happened to me and took me ~45 minutes to spot the issue.
