### PR TITLE
Disable raise php limits from \CSSmin

### DIFF
--- a/src/AssetsBundle/AssetFile/AssetFileFilter/CssAssetFileFilter.php
+++ b/src/AssetsBundle/AssetFile/AssetFileFilter/CssAssetFileFilter.php
@@ -41,7 +41,7 @@ class CssAssetFileFilter extends \AssetsBundle\AssetFile\AssetFileFilter\Abstrac
         if (!class_exists('CSSmin')) {
             throw new \LogicException('"CSSmin" class does not exist');
         }
-        return $this->cssMin = new \CSSmin();
+        return $this->cssMin = new \CSSmin(false);
     }
 
 }


### PR DESCRIPTION
Unit tests can not be achieved due to max_execution_time set by default to 60 seconds from class **\CSSmin**.